### PR TITLE
Update tuw-nlp to 0.0.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import find_packages, setup
 
+
+
+
 setup(
     name="xpotato",
     version="0.1.3",
@@ -24,8 +27,12 @@ setup(
         "streamlit == 1.3.1",
         "streamlit-aggrid == 0.2.3.post2",
         "scikit-criteria == 0.5",
-        "tuw-nlp == 0.0.8",
+        "tuw-nlp == 0.0.9",
         "amrlib == 0.6.0",
+        "protobuf==3.20.0",
+        "pytest >= 7.1.3",
+        "fastapi",
+        "uvicorn[standard]"
     ],
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
I called `pytest tests/test_ruleset.py`, started the backend and tested with `curl` (as written in the README), and I started the frontend as well. In addition, I checked all the files with `tuw-nlp` import for error (there wasn't any). I hope, that's it, but feel free to comment!

Btw, I added the libraries needed for testing to `setup.py`, if you don't want it that way, you/I can of course revert them.